### PR TITLE
Add configuration for console applications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,3 +14,7 @@ application {
     // Change this to your main class.
     mainClassName = "seedu.duke.Duke"
 }
+
+run {
+    standardInput = System.in
+}


### PR DESCRIPTION
Gradle defaults to an empty stdin which results in runtime exceptions
when attempting to read from `System.in`. Let's add some sensible
defaults for students who may still need to work with the standard
input stream.