### PR TITLE
Remove Typo in Tutorial 4

### DIFF
--- a/tutorials/javaFxTutorialPart4.md
+++ b/tutorials/javaFxTutorialPart4.md
@@ -172,7 +172,6 @@ Let's create a new `Main` class as the bridge between the existing logic in `Duk
 
 **Main.java**
 ```java
-@Override
 import java.io.IOException;
 
 import javafx.application.Application;


### PR DESCRIPTION
Resolves #40 
Remove unnecessary '@Override' at the start of the code example in tutorial 4 markdown.