### PR TITLE
Add clean task to UI redirection tests

### DIFF
--- a/text-ui-test/runtest.bat
+++ b/text-ui-test/runtest.bat
@@ -3,7 +3,7 @@ setlocal enableextensions
 pushd %~dp0
 
 cd ..
-call gradlew shadowJar
+call gradlew clean shadowJar
 
 cd build\libs
 for /f "tokens=*" %%a in (

--- a/text-ui-test/runtest.sh
+++ b/text-ui-test/runtest.sh
@@ -4,7 +4,7 @@
 cd "${0%/*}"
 
 cd ..
-./gradlew shadowJar
+./gradlew clean shadowJar
 
 cd text-ui-test
 


### PR DESCRIPTION
As old JARs may affect the results of the tests, let's ensure that clean
before running tests.