### PR TITLE
[#66] Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,18 +34,21 @@ jobs:
       - name: Build and check with Gradle
         run: ./gradlew check
 
-      - name: Perform IO redirection test (*NIX)
+      - name: Install dos2unix on Linux
         if: runner.os == 'Linux'
-        working-directory:  ${{ github.workspace }}/text-ui-test
-        run: ./runtest.sh
+        run: sudo apt-get update && sudo apt-get install -y dos2unix
 
-      - name: Perform IO redirection test (MacOS)
-        if: always() && runner.os == 'macOS'
-        working-directory:  ${{ github.workspace }}/text-ui-test
+      - name: Install dos2unix on macOS
+        if: runner.os == 'macOS'
+        run: brew install dos2unix
+
+      - name: Perform IO redirection test (*NIX or macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        working-directory: ${{ github.workspace }}/text-ui-test
         run: ./runtest.sh
 
       - name: Perform IO redirection test (Windows)
         if: always() && runner.os == 'Windows'
-        working-directory:  ${{ github.workspace }}/text-ui-test
+        working-directory: ${{ github.workspace }}/text-ui-test
         shell: cmd
         run: runtest.bat

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,11 +22,12 @@ jobs:
         run: git checkout --progress --force ${{ github.sha }}
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation@v3
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'zulu'
           java-version: '17'
           java-package: jdk+fx
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
         run: git checkout --progress --force ${{ github.sha }}
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
Update GitHub Actions workflow to latest versions

This PR updates the CI workflow with the following changes:

Upgrades the Gradle wrapper validation action from gradle/wrapper-validation-action@v1 to gradle/actions/wrapper-validation@v3.

Updates the Java setup step from actions/setup-java@v1 to actions/setup-java@v4, using JDK 17 with the jdk+fx package.

Installs dos2unix on both Ubuntu (apt-get) and macOS (brew) runners to normalize line endings and prevent issues with shell scripts across platforms.

These updates ensure the workflow uses the latest stable GitHub Actions and Java versions, improves cross-platform compatibility, and enhances security and maintainability.